### PR TITLE
タグのバリデーション関係の修正

### DIFF
--- a/src/components/SelectForm/index.tsx
+++ b/src/components/SelectForm/index.tsx
@@ -15,7 +15,9 @@ const SelectForm = (props: SelectFormProps) => {
         <select
           placeholder={placeholder}
           value={props.value} // ここにvalueプロパティを追加（編集ページの初期値表示のために必要）
-          className="border-blue-gray-200 text-blue-gray-700 placeholder-shown:border-blue-gray-200 disabled:bg-blue-gray-50 peer h-full w-full rounded-none border-b bg-transparent pb-2 pt-10 text-base font-normal outline outline-0 transition-all focus:border-orange-500 focus:outline-0 disabled:border-0"
+          className={`border-blue-gray-200 text-blue-gray-700 placeholder-shown:border-blue-gray-200 disabled:bg-blue-gray-50 peer h-full w-full rounded-none border-b bg-transparent pb-2 pt-10 text-base font-normal outline outline-0 transition-all focus:border-orange-500 focus:outline-0 disabled:border-0 ${
+            props.value === '' ? 'text-gray-400' : 'text-blue-gray-700'
+          }`}
           onChange={props.onChange}
         >
           <option value="">未選択</option>

--- a/src/pages/editrecipes/[id].tsx
+++ b/src/pages/editrecipes/[id].tsx
@@ -181,10 +181,14 @@ const EditRecipe = () => {
     return '';
   };
 
-  // タグ配列を確認するためのuseEffect
+  // _destroyがfalseのタグのみを確認するためのuseEffect
   useEffect(() => {
-    console.log(tags);
+    console.log(
+      '最新のタグ配列',
+      tags.filter((tag) => !tag._destroy)
+    );
   }, [tags]);
+
   // レシピとタグの詳細情報を確認するためのuseEffect
   useEffect(() => {
     console.log('レシピとタグ情報', recipe);
@@ -268,10 +272,18 @@ const EditRecipe = () => {
           <div className="ml-1 mr-4 mt-16">
             <TagButton
               onClick={() => {
-                if (tempTag) {
+                // _destroy が true でないタグのみをカウント
+                const validTagCount = tags.filter(
+                  (tag) => !tag._destroy
+                ).length;
+                // タグの数が 5 以下の場合のみ、タグを追加できるようにする。
+                if (tempTag && validTagCount < 5) {
                   setTags([...tags, { name: tempTag }]);
                   setTempTag('');
                   setInputValue('');
+                } else if (validTagCount >= 5) {
+                  // タグの数が 5 を超える場合のエラーメッセージを表示。
+                  alert('タグは5個までしか追加できません!');
                 }
               }}
             >

--- a/src/pages/recipes/[id].tsx
+++ b/src/pages/recipes/[id].tsx
@@ -119,7 +119,7 @@ const Recipes = () => {
         )}
       </div>
       {recipe?.title ? (
-        <div className="mx-2 mb-8 ml-7 whitespace-pre-wrap break-all rounded-md text-2xl font-bold text-orange-500">
+        <div className="mx-2 mb-8 ml-7 inline-block whitespace-pre-wrap break-all rounded-md text-2xl font-bold  text-orange-500">
           {recipe.title}
         </div>
       ) : (
@@ -158,13 +158,12 @@ const Recipes = () => {
           </div>
         </div>
       </div>
-      <div className="my-5 text-orange-500">カテゴリ</div>
-      <div className="my-1 text-orange-500">作り方</div>
-      <div className="rounded-sm bg-[#FDF1DE] px-2 py-2 shadow-md ">
+      <div className="mt-6 text-orange-500">作り方</div>
+      <div className="rounded-sm bg-[#FDF1DE] px-2 py-2 shadow-md">
         {/* 改行や空白を正しく表示させる処理 */}
         <div className="whitespace-pre-wrap break-all">{recipe?.content}</div>
       </div>
-      <div className="mt-5 text-orange-500">タグ</div>
+      <div className="mt-6 text-orange-500">タグ</div>
       {/* レシピに紐づくタグを表示 */}
       <div className="flex flex-wrap">
         {recipe?.tags.map((tag) => (

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,6 @@ module.exports = {
     './src/app/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
-
     extend: {
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',


### PR DESCRIPTION
・フロントエンドでタグの数を５個までのバリテーションを追加。 
・投稿ページのタグの追加処理を、編集ページの処理に合わせてID管理に修正。

Closes #92
Closes #93