### PR TITLE
各並べ替え用ボタンに、リクエスト送信の処理を追加。#173

### DIFF
--- a/src/components/RecipeList/index.tsx
+++ b/src/components/RecipeList/index.tsx
@@ -7,6 +7,8 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Link from 'next/link';
 import React from 'react';
+import { useRecoilState } from 'recoil';
+import { searchTypeState } from '../../state/search';
 import useAuth from '@/hooks/auth/useAuth';
 
 type Recipe = {
@@ -26,9 +28,11 @@ type Recipe = {
 type RecipeListProps = {
   recipes: Recipe[];
   loginCheck?: boolean;
+  setSearchType?: React.Dispatch<React.SetStateAction<string>>;
 };
 
 const RecipeList = (props: RecipeListProps) => {
+  const [searchType, setSearchType] = useRecoilState(searchTypeState); // 検索の種類をボタンを管理するステート。デフォルトは新着順。
   const { currentUser } = useAuth();
 
   // 数字を見やすくする関数(Kとかつける。　※最大9.9Kまで表示)
@@ -83,6 +87,39 @@ const RecipeList = (props: RecipeListProps) => {
   if (currentUser || props.loginCheck !== true) {
     return (
       <div className="select-none">
+        {/* 並び替え用のボタングループ */}
+        {props.loginCheck !== true ? (
+          <div className="mb-2 flex justify-end">
+            <div className="flex items-center">
+              <div className="mr-2 text-sm">並び替え ：</div>
+              <div className="flex items-center">
+                <button
+                  className={
+                    'mr-2 rounded-md px-1 py-0.5 text-sm hover:bg-[#FDF1DE] hover:text-orange-500 hover:underline ' +
+                    (searchType === 'rank' ? 'text-orange-500' : '')
+                  }
+                  onClick={() => {
+                    setSearchType?.('rank');
+                  }}
+                >
+                  人気順
+                </button>
+                <p className="ml-1 mr-2">/</p>
+                <button
+                  className={
+                    'mr-2 rounded-md px-1 py-0.5 text-sm hover:bg-[#FDF1DE] hover:text-orange-500 hover:underline ' +
+                    (searchType === 'new' ? 'text-orange-500' : '')
+                  }
+                  onClick={() => {
+                    setSearchType?.('new');
+                  }}
+                >
+                  新着順
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : null}
         <div>
           {props.recipes.map((recipe) => (
             <div

--- a/src/components/Sidemenu/index.tsx
+++ b/src/components/Sidemenu/index.tsx
@@ -20,7 +20,7 @@ import useAuth from '@/hooks/auth/useAuth';
 
 // SideMenuPropsを定義
 
-// isMenuOpenはboolean型、setIsMenuOpenはReact.Dispatch<React.SetStateAction<boolean>>型である。
+// isMenuOpenはboolean型、setIsMenuOpenはReact.Dispatch<React.SetStateAction<boolean>型である。
 type SideMenuProps = {
   isMenuOpen: boolean;
   setIsMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -30,6 +30,7 @@ export default function App({ Component, pageProps }: AppProps) {
       <div className="mx-auto flex h-screen w-screen flex-col bg-white outline outline-2 outline-[#FDF1DE] lg:w-1/3 ">
         <Header />
         <div className="flex-1 overflow-y-auto overscroll-none px-4 pb-36 pt-5 lg:px-6 lg:pb-10">
+          {/* ログインユーザーがいない場合はロード中を表示 */}
           {isWaitingUser ? (
             <p>ロード中...</p>
           ) : (

--- a/src/state/search.ts
+++ b/src/state/search.ts
@@ -25,3 +25,9 @@ export const searchResultState = atom<Recipe[]>({
   key: 'searchResultState',
   default: [], // 初期状態は空の配列
 });
+
+// 検索タイプの状態を管理する
+export const searchTypeState = atom<string>({
+  key: 'searchTypeState',
+  default: 'new', // 初期状態は新着検索
+});


### PR DESCRIPTION
各並べ替え用ボタンに、リクエスト送信の処理を追加。
検索結果を新着と人気順で切り替えられるように修正。
Recoilステートを使い、ボタンの押下により検索タイプ（新着or人気）を切り替えられるように処理を追加。

Closes #173